### PR TITLE
Add Linux keytar dependency warning to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ goe://<repo_address>:<chain_id>
 npm install -g goe-cli
 ```
 
-> **Linux Users:**  
+> ⚠️ **Note for Linux Users:**  
 > On Linux systems, GoE CLI depends on `keytar` for secure key storage.  
 > If your system is missing `libsecret-1.so.0` or other required libraries, keytar will fail, and GoE CLI may not start.  
 > To fix this, install the required system libraries (e.g., `sudo apt install libsecret-1-dev` on Debian/Ubuntu).


### PR DESCRIPTION
This PR updates the GoE documentation to include a note for Linux users. This helps Linux users avoid startup issues.