### PR TITLE
Support ens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,6 @@ With GoE, your code is:
 
 ---
 
-## How GoE Works
-
-GoE uses a three-layer model for seamless Git integration:
-
-1. **Git Remote Helper** — handles the `goe://` protocol for all Git commands.
-2. **[Ethereum Smart Contracts](https://github.com/ethstorage/goe-contracts)** — manage branches, commits, and access permissions on-chain.
-3. **EthStorage (EIP-4844 Blob)** — stores large Git data objects efficiently on Ethereum L2.
-
-📘 **Design Document:**  
-For a deeper technical overview of GoE's architecture and on-chain Git mechanics, see our [design doc](https://github.com/ethstorage/ethfs-git/pull/1/files).
-
----
-
-## `goe://` Protocol
-
-GoE repositories are identified on-chain by their contract addresses. The goe:// protocol lets you reference a repository in three ways:
-
-| URI Format                                 | Type      | Resolution Logic                                     |
-|--------------------------------------------|-----------|------------------------------------------------------|
-| ```goe://<repo_address>:<chain_id>```      | Canonical | Direct access via on-chain contract address          | 
-| ```goe://<repo_name>:<chain_id>```         | Shorthand | Resolves via the current wallet and repository name  | 
-| ```goe://<owner>/<repo_name>:<chain_id>``` | Full Path | Resolves via any owner’s address and repository name | 
-
-> **Note:** `<repo_address>` refers to the repository's smart contract; `<chain_id>` is the blockchain network ID.
-
----
-
-
-
 ## Getting Started
 
 ### 1. Install the CLI
@@ -189,6 +160,63 @@ goe repo default-branch <repo_address|repo_name> master --chain-id 11155111
 ```bash
 goe repo grant-push <repo_address|repo_name> <collaborator_address> --chain-id 11155111
 ```
+
+---
+
+## How GoE Works
+
+GoE uses a three-layer model for seamless Git integration:
+
+1. **Git Remote Helper** — handles the `goe://` protocol for all Git commands.
+2. **[Ethereum Smart Contracts](https://github.com/ethstorage/goe-contracts)** — manage branches, commits, and access permissions on-chain.
+3. **EthStorage (EIP-4844 Blob)** — stores large Git data objects efficiently on Ethereum L2.
+
+📘 **Design Document:**  
+For a deeper technical overview of GoE's architecture and on-chain Git mechanics, see our [design doc](https://github.com/ethstorage/ethfs-git/pull/1/files).
+
+---
+
+## `goe://` Protocol
+
+Each GoE repository has a canonical on-chain contract address.
+The `goe://` protocol lets you reference the same repository in multiple human-readable ways:
+
+| URI Format                                         | Resolution Logic                                                   |
+|----------------------------------------------------|--------------------------------------------------------------------|
+| ```goe://<repo_contract_address>:<chain_id>```     | Canonical, unambiguous reference to a deployed repository contract | 
+| ```goe://<owner_address>:<chain_id>/<repo_name>``` | Owner address + repository name                                    | 
+| ```goe://<ens_name>:<chain_id>/<repo_name>```      | ENS-based, human-readable form (recommended)                       | 
+
+- ```<chain_id>``` specifies the blockchain network where the repository exists.
+- ```<repo_name>``` must follow on-chain validation rules (alphanumeric and -._, max 100 chars).
+
+### Resolution Rules
+- Contract address → used directly
+- Otherwise → `<owner>` (address or ENS) + `<repo_name>` → resolved on-chain
+
+### Notes
+- Shorthand `goe://<repo_name>` **not supported** in Git remotes
+- `goe CLI` may accept `<repo_name>` for repositories owned by the current wallet
+
+---
+
+
+## Advanced: ENS & Local Wallet Mapping (Optional)
+
+Your Local Wallet (via `goe wallet create`) handles Git operations.  
+For ENS URLs (`goe://yourname.eth:1/repo`), map your ENS to this wallet to allow Git access.
+
+### How to link your Local Wallet to ENS:
+
+1). Run `goe wallet list` → copy Local Wallet address
+2). Add an ENS Text Record: 
+Use an ENS manager (e.g., [ens.domains](ens.domains)) with your Primary Wallet to add a Text Record to your domain:
+- Key: `goe://`
+- Value: `0xYourLocalWalletAddress`
+
+When someone (or your CLI) accesses goe://yourname.eth:1/repo, GoE will query the record and automatically use your Local Wallet address as the owner.
+
+---
 
 
 ## Additional Reference

--- a/src/core/contracts/resolver/index.ts
+++ b/src/core/contracts/resolver/index.ts
@@ -1,48 +1,103 @@
 import { ethers, ZeroAddress } from "ethers";
 import { getHubContract } from "../hub.js";
+import { getNetworkConfig, randomRPC } from "../utils.js";
 
+/**
+ * Resolves a repository identifier to its contract address.
+ *
+ * CLI supports shorthand repoName (defaultOwner required).
+ * Git helper must always provide full URI (owner/repo or contract address).
+ */
 export async function resolveRepoAddress(
     chainId: number,
     input: string,
     defaultOwner?: string
 ): Promise<string> {
-    // 1. address
+    // 1. Direct address check
     const strInput: string = input; // fix ts build bug
     if (ethers.isAddress(strInput)) {
         return strInput;
     }
 
-    // 2. owner/repo
-    if (input.includes("/")) {
-        const [owner, repoName] = input.split("/");
-        if (!owner || !repoName) {
-            throw new Error(`Invalid repo identifier: "${input}"`);
+    let ownerIdentifier: string;
+    let repoName: string;
+
+    // 2. Determine if it's a full path (owner/repo) or shorthand (repo)
+    const slashIndex = input.indexOf("/");
+    if (slashIndex !== -1) {
+        // Handle "owner/repo" or "owner.eth/repo/sub-path"
+        ownerIdentifier = input.substring(0, slashIndex);
+        repoName = input.substring(slashIndex + 1);
+        if (!ownerIdentifier || !repoName) {
+            throw new Error(`Invalid repository identifier format: "${input}"`);
         }
-        if (ethers.isAddress(repoName)) {
-            throw new Error(
-                `Invalid repo identifier "${input}". Use repo address directly.`
-            );
+    } else {
+        // Shorthand: repoName only
+        if (!defaultOwner) {
+            throw new Error(`Owner identification required to resolve repository: "${input}"`);
         }
-        return await resolveByName(chainId, owner, repoName);
+        ownerIdentifier = defaultOwner;
+        repoName = input;
     }
 
-    // 3. repoName only
-    if (!defaultOwner) {
-        throw new Error(`Owner is required to resolve repo name "${input}"`);
-    }
-    return await resolveByName(chainId, defaultOwner, input);
+    // 3. Resolve Identity (ENS with goe:// worker logic or direct Address)
+    const finalOwner = await resolveOwnerAddress(chainId, ownerIdentifier);
+
+    // 4. Fetch Repo address from the Factory (Hub) contract
+    return await resolveByName(chainId, finalOwner, repoName);
 }
 
+/**
+ * Resolves the owner's address.
+ * Supports ENS resolution with a fallback to the "goe://" text record (worker wallet).
+ */
+async function resolveOwnerAddress(chainId: number, ownerIdentifier: string): Promise<string> {
+    const owner: string = ownerIdentifier; // fix ts build bug
+    if (ethers.isAddress(owner)) {
+        return owner;
+    }
+
+    if (ownerIdentifier.endsWith(".eth")) {
+        const network = getNetworkConfig(chainId);
+        const rpcUrl = randomRPC(network.rpc);
+        const provider = new ethers.JsonRpcProvider(rpcUrl);
+
+        const resolver = await provider.getResolver(ownerIdentifier);
+        if (!resolver) {
+            throw new Error(`ENS resolver not found for domain: ${ownerIdentifier}`);
+        }
+
+        // 1. Priority: Try to get the dedicated GOE worker address from Text Records
+        const workerAddr = await resolver.getText("goe://");
+        if (workerAddr && ethers.isAddress(workerAddr)) {
+            return workerAddr;
+        }
+
+        // 2. Fallback: Use the primary ETH address bound to the ENS name
+        const ownerAddr = await resolver.getAddress();
+        if (!ownerAddr || ownerAddr === ZeroAddress) {
+            throw new Error(`ENS name "${ownerIdentifier}" does not resolve to a valid address`);
+        }
+        return ownerAddr;
+    }
+
+    throw new Error(`Invalid owner identifier: "${ownerIdentifier}". Must be an Ethereum address or .eth domain.`);
+}
+
+/**
+ * Queries the Hub/Factory contract to find the repository address by owner and name.
+ */
 async function resolveByName(
     chainId: number,
     owner: string,
     repoName: string
 ): Promise<string> {
     const factory = await getHubContract(chainId);
-    repoName = ethers.hexlify(ethers.toUtf8Bytes(repoName));
-    const repo = await factory.getRepoByName(owner, repoName);
-    if (!repo || repo === ZeroAddress) {
-        throw new Error(`Repository "${owner}/${repoName}" not found`);
+    // Convert string name to hex bytes as required by the contract
+    const repoNameBytes = ethers.hexlify(ethers.toUtf8Bytes(repoName));
+    const repoAddress = await factory.getRepoByName(owner, repoNameBytes);
+    if (!repoAddress || repoAddress === ZeroAddress) {
+        throw new Error(`Repository "${repoName}" owned by "${owner}" not found on chain ${chainId}`);
     }
-    return repo;
+    return repoAddress;
 }


### PR DESCRIPTION
This PR introduces support for ENS-based repository references in GoE. Users can now use goe://<ens_name>.eth:<chain_id>/<repo_name> URIs alongside existing contract-address and owner-address formats. The CLI resolves ENS names to the corresponding repository contract, optionally supporting worker wallet mappings for Git operations.

Test: git clone goe://goe.eth:11155111/bl111  √